### PR TITLE
Update AzureDevOpsCredentialsPlugin.scala

### DIFF
--- a/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
+++ b/src/main/scala/dev/chungmin/sbt/AzureDevOpsCredentialsPlugin.scala
@@ -33,7 +33,7 @@ object AzureDevOpsCredentialsPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override lazy val projectSettings = Seq(
-    credentials ++= buildCredentials(credentials.value, resolvers.value, streams.value.log),
+    credentials ++= buildCredentials(credentials.value, externalResolvers.value, streams.value.log),
 
     // Fix for https://github.com/coursier/coursier/issues/1649
     csrConfiguration := updateCoursierConf(


### PR DESCRIPTION
Use "externalResolvers" instead of "resolvers" since the former will include the later and updating the former is the only way of using a custom feed and not using any of the default ones.

Reference: https://www.scala-sbt.org/1.x/docs/Library-Management.html#Override+default+resolvers